### PR TITLE
Fix snake tail flicker

### DIFF
--- a/index.html
+++ b/index.html
@@ -817,7 +817,29 @@
         const blend = 0.65
         for (let i = 0; i < targetPath.length; i++) {
             const target = targetPath[i]
-            if (i === 0 || i === targetPath.length - 1 || i >= prev.length) {
+            if (i === 0) {
+                const prevPoint = prev[0]
+                if (!prevPoint) {
+                    smoothed.push({ x: target.x, y: target.y })
+                } else {
+                    const tailDist = Math.hypot(target.x - prevPoint.x, target.y - prevPoint.y)
+                    if (tailDist > SEGMENT_SPACING * 12) {
+                        smoothed.push({ x: target.x, y: target.y })
+                    } else {
+                        const tailBlend = tailDist > SEGMENT_SPACING * 4 ? 0.55 : 0.35
+                        smoothed.push({
+                            x: lerp(prevPoint.x, target.x, tailBlend),
+                            y: lerp(prevPoint.y, target.y, tailBlend)
+                        })
+                    }
+                }
+            } else if (i === 1 && prev.length > 1) {
+                const point = prev[1]
+                smoothed.push({
+                    x: lerp(point.x, target.x, 0.55),
+                    y: lerp(point.y, target.y, 0.55)
+                })
+            } else if (i === targetPath.length - 1 || i >= prev.length) {
                 smoothed.push({ x: target.x, y: target.y })
             } else {
                 const point = prev[i]

--- a/src/world.js
+++ b/src/world.js
@@ -79,6 +79,44 @@ function resamplePath(points, spacing) {
     return output
 }
 
+function computePathLength(points) {
+    let sum = 0
+    for (let i = 1; i < points.length; i++) {
+        const prev = points[i - 1]
+        const cur = points[i]
+        sum += Math.hypot(cur.x - prev.x, cur.y - prev.y)
+    }
+    return sum
+}
+
+function trimPathToLength(player, maxLength) {
+    const target = Math.max(0, maxLength)
+    while (player.path.length > 1 && player.pathLen > target) {
+        const first = player.path[0]
+        const second = player.path[1]
+        const segLen = Math.hypot(second.x - first.x, second.y - first.y)
+        if (!Number.isFinite(segLen) || segLen === 0) {
+            player.path.shift()
+            continue
+        }
+        const excess = player.pathLen - target
+        if (excess >= segLen - 1e-6) {
+            player.path.shift()
+            player.pathLen -= segLen
+            if (player.pathLen < 0) player.pathLen = 0
+        } else {
+            const ratio = excess / segLen
+            player.path[0] = {
+                x: first.x + (second.x - first.x) * ratio,
+                y: first.y + (second.y - first.y) * ratio
+            }
+            player.pathLen -= excess
+            if (player.pathLen < 0) player.pathLen = 0
+            break
+        }
+    }
+}
+
 class World {
     constructor(cfg, killLogger) {
         this.cfg = cfg
@@ -143,8 +181,9 @@ class World {
             length: this.cfg.baseLength,
             alive: true,
             boost: false,
-            path: [],
+            path: [{ x: spawn.x, y: spawn.y }],
             pathLen: 0,
+            pathCarry: 0,
             lastDrop: 0,
             lastSeenTick: 0,
             lastInputTs: 0,
@@ -177,8 +216,9 @@ class World {
         p.length = this.cfg.baseLength
         p.alive = true
         p.boost = false
-        p.path = []
+        p.path = [{ x: p.x, y: p.y }]
         p.pathLen = 0
+        p.pathCarry = 0
         p.r = this.cfg.headRadius
     }
 
@@ -226,25 +266,62 @@ class World {
             p.x = border.x
             p.y = border.y
 
-            // записываем точку пути, если голова прошла достаточно расстояния
-            const last = p.path[p.path.length - 1]
-            if (
-                !last ||
-                dist2(last.x, last.y, p.x, p.y) >
-                this.cfg.pathPointSpacing * this.cfg.pathPointSpacing
-            ) {
-                p.path.push({ x: p.x, y: p.y })
+            // обновляем полилинию хвоста
+            const spacing = this.cfg.segmentSpacing
+            if (!Array.isArray(p.path) || p.path.length === 0) {
+                p.path = [{ x: p.x, y: p.y }]
+                p.pathLen = 0
+                p.pathCarry = 0
+            } else {
+                const previousHead = p.path[p.path.length - 1]
+                const dx = p.x - previousHead.x
+                const dy = p.y - previousHead.y
+                const distance = Math.hypot(dx, dy)
+                if (distance > 0) {
+                    let consumed = 0
+                    while (p.pathCarry + (distance - consumed) >= spacing) {
+                        const step = spacing - p.pathCarry
+                        consumed += step
+                        const t = consumed / distance
+                        const nx = previousHead.x + dx * t
+                        const ny = previousHead.y + dy * t
+                        p.path.push({ x: nx, y: ny })
+                        p.pathLen += step
+                        p.pathCarry = 0
+                    }
+                    const remainder = distance - consumed
+                    if (remainder > 1e-6) {
+                        p.pathCarry += remainder
+                        p.pathLen += remainder
+                    } else {
+                        p.pathCarry = 0
+                    }
+                    const lastPoint = p.path[p.path.length - 1]
+                    if (!lastPoint || Math.hypot(lastPoint.x - p.x, lastPoint.y - p.y) > 1e-5) {
+                        p.path.push({ x: p.x, y: p.y })
+                    } else {
+                        lastPoint.x = p.x
+                        lastPoint.y = p.y
+                    }
+                } else {
+                    const headPoint = p.path[p.path.length - 1]
+                    if (headPoint) {
+                        headPoint.x = p.x
+                        headPoint.y = p.y
+                    } else {
+                        p.path.push({ x: p.x, y: p.y })
+                    }
+                }
             }
 
-            // считаем максимальное количество сегментов для хвоста
-            const maxSegments = Math.floor(p.length / this.cfg.segmentSpacing)
-            if (p.path.length > maxSegments) {
-                p.path = p.path.slice(p.path.length - maxSegments)
-            }
+            // обрезаем хвост по целевой длине
+            const desiredPathLength = Math.max(spacing * 2, p.length)
+            trimPathToLength(p, desiredPathLength)
 
             // ограничитель (безопасность, если что-то пошло не так)
             if (p.path.length > this.cfg.maxPathPoints) {
                 p.path = p.path.slice(p.path.length - this.cfg.maxPathPoints)
+                p.pathLen = computePathLength(p.path)
             }
 
             // буст — отнимаем длину и дропаем еду
@@ -330,6 +407,8 @@ class World {
 
         const dropPath = victim.path.slice()
         victim.path = []
+        victim.pathLen = 0
+        victim.pathCarry = 0
 
         const totalValue = Math.max(1, Math.floor(victim.length))
         const palette = this.skinPalette(victim.skin)


### PR DESCRIPTION
## Summary
- track the full snake path on the server and trim the tail gradually instead of chopping whole segments
- keep the client tail interpolation smooth so the round cap stays stable

## Testing
- node -e "require('./src/world'); console.log('world ok')"


------
https://chatgpt.com/codex/tasks/task_e_68d57a6cc4ec8331b0ac7700df9cfb0d