### PR TITLE
Expand client path sampling for long tails

### DIFF
--- a/index.html
+++ b/index.html
@@ -778,7 +778,11 @@
 
     function rebuildPath(points, headX, headY, length, angle) {
         const result = []
-        const tail = points.slice(-Math.min(points.length, 400))
+        const sourcePoints = Array.isArray(points) ? points : []
+        const targetLength = Math.max(typeof length === 'number' ? length : 0, SEGMENT_SPACING * 2)
+        const maxPoints = Math.max(2, 1 + Math.ceil(targetLength / SEGMENT_SPACING))
+        const sampleWindow = Math.min(sourcePoints.length, Math.max(400, maxPoints + 12))
+        const tail = sourcePoints.slice(-sampleWindow)
         for (let i = 0; i < tail.length; i++) {
             const pt = tail[i]
             if (typeof pt.x === 'number' && typeof pt.y === 'number') {
@@ -797,8 +801,6 @@
             })
         }
         let resampled = resamplePath(result, SEGMENT_SPACING)
-        const targetLength = Math.max(typeof length === 'number' ? length : 0, SEGMENT_SPACING * 2)
-        const maxPoints = Math.max(2, 1 + Math.ceil(targetLength / SEGMENT_SPACING))
         if (resampled.length > maxPoints) {
             resampled = resampled.slice(resampled.length - maxPoints)
         }
@@ -827,10 +829,11 @@
                     smoothed.push({ x: target.x, y: target.y })
                 } else {
                     const tailDist = Math.hypot(target.x - prevPoint.x, target.y - prevPoint.y)
-                    if (tailDist > SEGMENT_SPACING * 12) {
+                    if (tailDist > SEGMENT_SPACING * 8) {
                         smoothed.push({ x: target.x, y: target.y })
                     } else {
-                        const tailBlend = tailDist > SEGMENT_SPACING * 4 ? 0.55 : 0.35
+                        const normalized = Math.min(1, Math.max(0, tailDist / (SEGMENT_SPACING * 2)))
+                        const tailBlend = 0.45 + normalized * 0.45
                         smoothed.push({
                             x: lerp(prevPoint.x, target.x, tailBlend),
                             y: lerp(prevPoint.y, target.y, tailBlend)


### PR DESCRIPTION
## Summary
- derive the maximum required segment count from the reported snake length
- keep an expanded slice of the server path so long tails use authoritative points instead of extrapolation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5affa3820833182f4631ceb7a3d39