### PR TITLE
Ensure snake tail follows recorded head path

### DIFF
--- a/index.html
+++ b/index.html
@@ -821,31 +821,11 @@
         const smoothed = []
         const prev = snake.renderPath
         const blend = 0.65
+        const tailLock = Math.min(6, targetPath.length)
         for (let i = 0; i < targetPath.length; i++) {
             const target = targetPath[i]
-            if (i === 0) {
-                const prevPoint = prev[0]
-                if (!prevPoint) {
-                    smoothed.push({ x: target.x, y: target.y })
-                } else {
-                    const tailDist = Math.hypot(target.x - prevPoint.x, target.y - prevPoint.y)
-                    if (tailDist > SEGMENT_SPACING * 8) {
-                        smoothed.push({ x: target.x, y: target.y })
-                    } else {
-                        const normalized = Math.min(1, Math.max(0, tailDist / (SEGMENT_SPACING * 2)))
-                        const tailBlend = 0.45 + normalized * 0.45
-                        smoothed.push({
-                            x: lerp(prevPoint.x, target.x, tailBlend),
-                            y: lerp(prevPoint.y, target.y, tailBlend)
-                        })
-                    }
-                }
-            } else if (i === 1 && prev.length > 1) {
-                const point = prev[1]
-                smoothed.push({
-                    x: lerp(point.x, target.x, 0.55),
-                    y: lerp(point.y, target.y, 0.55)
-                })
+            if (i < tailLock) {
+                smoothed.push({ x: target.x, y: target.y })
             } else if (i === targetPath.length - 1 || i >= prev.length) {
                 smoothed.push({ x: target.x, y: target.y })
             } else {
@@ -959,31 +939,6 @@
         }
     }
 
-    function extendPathFront(points, amount, spacing) {
-        if (!Array.isArray(points) || points.length < 2) return
-        if (!Number.isFinite(amount) || amount <= LENGTH_EPS) return
-
-        // берём два первых (хвостовые) пункта и экстраполируем один новый
-        normalizePathStart(points)
-        if (points.length < 2) return
-
-        const first = points[0]
-        const second = points[1]
-        const dx = first.x - second.x
-        const dy = first.y - second.y
-        const segLen = Math.hypot(dx, dy)
-        if (segLen <= LENGTH_EPS) return
-
-        const ux = dx / segLen
-        const uy = dy / segLen
-        // не делаем много мелких вставок — один аккуратный префикс
-        const toAdd = Math.min(amount, Math.max(spacing || SEGMENT_SPACING, amount))
-        points.unshift({
-            x: first.x + ux * toAdd,
-            y: first.y + uy * toAdd
-        })
-    }
-
     function fitPathLength(points, targetLength, spacing) {
         if (!Array.isArray(points) || points.length < 2) return
         const safeTarget = Math.max(targetLength || 0, SEGMENT_SPACING * 2)
@@ -991,10 +946,6 @@
         if (!Number.isFinite(total)) return
         if (total > safeTarget + SEGMENT_SPACING * 0.25) {
             trimPathFront(points, total - safeTarget)
-            total = pathLength(points)
-        }
-        if (total + SEGMENT_SPACING * 0.25 < safeTarget) {
-            extendPathFront(points, safeTarget - total, spacing)
         }
     }
 


### PR DESCRIPTION
## Summary
- keep the first segments of each snake path identical to the server-provided polyline so the tail follows the exact trajectory
- remove client-side path extension logic that fabricated extra tail points beyond the recorded path

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6500319488331b0be374c37e9bfb1